### PR TITLE
Adds blob to url functions

### DIFF
--- a/src/Web/File/URL.js
+++ b/src/Web/File/URL.js
@@ -1,0 +1,13 @@
+"use strict";
+
+exports.createObjectURL = function (blob) {
+  return function () {
+    return URL.createObjectURL(blob);
+  };
+};
+
+exports.revokeObjectURL = function (url) {
+  return function () {
+    URL.revokeObjectURL(url);
+  };
+};

--- a/src/Web/File/URL.purs
+++ b/src/Web/File/URL.purs
@@ -1,0 +1,18 @@
+module Web.File.Url 
+  (createObjectURL
+  , revokeObjectURL
+  ) where
+
+import Prelude
+import Effect (Effect)
+import Web.File.Blob (Blob)
+
+
+-- | Adds this blob to the url store
+-- | The string is a url that can be used to
+-- | 'download' the blob
+foreign import createObjectURL :: Blob -> Effect String
+
+-- | Revoke a blob url from the url store
+-- | Doesn't throw errors on failure
+foreign import revokeObjectURL :: String -> Effect Unit


### PR DESCRIPTION
These are from the fileapi
at https://www.w3.org/TR/FileAPI/#creating-revoking

These functions allow a url to be created from
a blob, and for that url to be revoked.

This allows parts of the dom to 'use' the blob
as if it were an asset loaded by the browser