### PR TITLE
Export `error` method from FileReader

### DIFF
--- a/src/Web/File/FileReader.purs
+++ b/src/Web/File/FileReader.purs
@@ -3,6 +3,7 @@ module Web.File.FileReader
   , fromEventTarget
   , toEventTarget
   , fileReader
+  , error
   , readyState
   , result
   , abort


### PR DESCRIPTION
Looks like an unintentional omission since it’s not referenced otherwise?